### PR TITLE
Support for default sizes via configuration

### DIFF
--- a/lib/next-plugin/nextPlugin.js
+++ b/lib/next-plugin/nextPlugin.js
@@ -8,6 +8,9 @@ const defaults = {
   breakpoints: [768],
   densities: ['1x', '2x'],
 
+  // fallback sizes if not defined in image query
+  sizes: [Number.MAX_SAFE_INTEGER],
+
   // TODO - implement
   // inlineImageLimit: 8192,
 
@@ -107,6 +110,7 @@ module.exports = function withImg(pluginConfig = {}, nextComposePlugins = {}) {
 
 function getLoaderOptions(pluginConfig, nextConfig, nextComposePlugins) {
   const {
+    sizes,
     densities,
     jpeg,
     png,
@@ -143,6 +147,7 @@ function getLoaderOptions(pluginConfig, nextConfig, nextComposePlugins) {
   return {
     // these come from the next-img plugin config, but it is possible to
     // override them in the individual requires
+    sizes,
     densities,
     jpeg,
     png,

--- a/lib/webpack-loader/loader.js
+++ b/lib/webpack-loader/loader.js
@@ -88,10 +88,11 @@ module.exports.gc = gc
 async function load(filePath, buffer) {
   // parse the configuration and combine the loader query config with that passed in via webpack config
   const queryKeys = ['sizes', 'densities', 'jpeg', 'png', 'webp']
-  const queryConfig = parseResourceQuery(this.resourceQuery, queryKeys)
-  queryConfig.sizes = queryConfig.sizes || [Number.MAX_SAFE_INTEGER]
+  const queryConfig = parseResourceQuery(this.resourceQuery, queryKeys)  
   const loaderConfig = loaderUtils.getOptions(this)
-  const config = merge({}, loaderConfig, queryConfig)
+  const config = merge({
+    sizes: [Number.MAX_SAFE_INTEGER]
+  }, loaderConfig, queryConfig)
 
   // some webpack voodoo
   const loaderContext = this


### PR DESCRIPTION
Is there a reason not to suppot default sizes via configuration? I know selecting sizes based on each image usage would get better results, but for some projects it might be at least better to have a default set of resizes than to have one size only.