### PR TITLE
fix(Picture): Extend support for string based media breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ import img5 from './images/img.jpg?sizes=375,900&densities=1x,2x,3x&jpeg[quality
 Here are the props this component accepts:
 
 - **src** the imported image, or an array of imported images.
-- **breakpoints** - a list of breakpoints to override the global configuration.
+- **breakpoints** - a list of breakpoints to override the global configuration. Each breakpoint can be a pixel width, such as `768`, or a complete media condition, such as `'(orientation: landscape)'`.
 - **sizes** - a custom [html sizes attribute](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#How_do_you_create_responsive_images), by default the sizes attribute is generated based on the available images and breakpoints.
 - **the rest of the props and ref** are forwarded to the `img` tag. This allows the use of attributes such as `alt`, `loading="lazy"`, etc..
 
@@ -231,6 +231,12 @@ For example, with breakpoints `[375, 768]` and `src=[img1, img2, img3]` the `<Pi
   <source sizes="{{img3 width}}" />
   <img ... />
 </picture>
+```
+
+String breakpoints are used as-is, allowing art direction based on conditions other than width:
+
+```js
+<Picture src={[landscape, fallback]} breakpoints={['(orientation: landscape)']} />
 ```
 
 ## Turbopack Compatibility

--- a/lib/Picture.js
+++ b/lib/Picture.js
@@ -3,6 +3,7 @@ const React = require('react')
 const h = React.createElement
 
 const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...imgProps }, ref) {
+
   if (!src) {
     return null
   }
@@ -49,7 +50,7 @@ const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...
   return h(
     'picture',
     {},
-    flattendSrc.map(({ img, sizes, breakpoints, maxWidth }, i) =>
+    flattendSrc.map(({ img, sizes, breakpoints, media }, i) =>
       h(
         React.Fragment,
         { key: i },
@@ -59,7 +60,7 @@ const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...
             type: 'image/webp',
             srcSet: img.webpSrcSet,
             sizes: makeSizes(img, sizes, breakpoints),
-            ...(maxWidth ? { media: `(max-width: ${maxWidth}px)` } : {}),
+            media,
           }),
         img.srcSet &&
           img.srcSet.length > 0 &&
@@ -67,7 +68,7 @@ const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...
             type: img.type,
             srcSet: img.srcSet,
             sizes: makeSizes(img, sizes, breakpoints),
-            ...(maxWidth ? { media: `(max-width: ${maxWidth}px)` } : {}),
+            media,
           }),
       ),
     ),
@@ -86,11 +87,13 @@ function flattenSrc(src, sizes, breakpoints) {
       continue
     }
 
+    const breakpoint = typeof breakpoints[i] === 'number' ? `(max-width: ${breakpoints[i]}px)` : breakpoints[i]
+
     result.push({
       img: src[i],
       sizes: sizes[i],
       breakpoints: src.length === 1 ? breakpoints : [],
-      maxWidth: i === src.length - 1 ? null : breakpoints[i],
+      media: i === src.length - 1 ? null : breakpoint,
     })
   }
 

--- a/lib/Picture.js
+++ b/lib/Picture.js
@@ -59,7 +59,7 @@ const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...
             type: 'image/webp',
             srcSet: img.webpSrcSet,
             sizes: makeSizes(img, sizes, breakpoints),
-            ...(maxWidth ? { media: `(max-width: ${maxWidth}px)` } : {}),
+            ...(maxWidth ? { media: makeMedia(maxWidth) } : {}),
           }),
         img.srcSet &&
           img.srcSet.length > 0 &&
@@ -67,7 +67,7 @@ const Picture = React.forwardRef(function Picture({ src, sizes, breakpoints, ...
             type: img.type,
             srcSet: img.srcSet,
             sizes: makeSizes(img, sizes, breakpoints),
-            ...(maxWidth ? { media: `(max-width: ${maxWidth}px)` } : {}),
+            ...(maxWidth ? { media: makeMedia(maxWidth) } : {}),
           }),
       ),
     ),
@@ -111,10 +111,14 @@ function makeSizes(img, sizes, breakpoints) {
       }
 
       return breakpoints[i] && img.sizes.length - 1 > i
-        ? acc.concat(`(max-width: ${breakpoints[i]}px) ${s}px`)
+        ? acc.concat(`${makeMedia(breakpoints[i])} ${s}px`)
         : acc.concat(`${s}px`)
     }, [])
     .join(', ')
+}
+
+function makeMedia(breakpoint) {
+  return typeof breakpoint === 'number' ? `(max-width: ${breakpoint}px)` : breakpoint
 }
 
 module.exports = { Picture, makeSizes, flattenSrc }

--- a/test/Picture.test.js
+++ b/test/Picture.test.js
@@ -115,6 +115,45 @@ test('makeSizes', t => {
     makeSizes({ sizes: [200, 800, 1200] }, null, breakpoints),
     '(max-width: 768px) 200px, (max-width: 1024px) 800px, 1200px',
   )
+
+  breakpoints = ['(orientation: landscape)']
+  t.is(makeSizes({ sizes: [200, 800] }, null, breakpoints), '(orientation: landscape) 200px, 800px')
+
+  breakpoints = [768, '(orientation: landscape)']
+  t.is(
+    makeSizes({ sizes: [200, 800, 1200] }, null, breakpoints),
+    '(max-width: 768px) 200px, (orientation: landscape) 800px, 1200px',
+  )
+})
+
+test('media-query breakpoints', t => {
+  const landscape = {
+    src: 'landscape.jpg',
+    type: 'image/jpeg',
+    srcSet: 'landscape.jpg 800w',
+    images: [{ width: 800, height: 450 }],
+    name: 'landscape.jpg',
+    sizes: [800],
+    breakpoints: [],
+  }
+  const fallback = {
+    src: 'fallback.jpg',
+    type: 'image/jpeg',
+    srcSet: 'fallback.jpg 800w',
+    images: [{ width: 800, height: 800 }],
+    name: 'fallback.jpg',
+    sizes: [800],
+    breakpoints: [],
+  }
+
+  t.is(
+    renderToStaticMarkup(<Picture src={[landscape, fallback]} breakpoints={['(orientation: landscape)']} />),
+    '<picture>' +
+      '<source type="image/jpeg" srcSet="landscape.jpg 800w" sizes="800px" media="(orientation: landscape)"/>' +
+      '<source type="image/jpeg" srcSet="fallback.jpg 800w" sizes="800px"/>' +
+      '<img src="landscape.jpg" srcSet="landscape.jpg 800w"/>' +
+      '</picture>',
+  )
 })
 
 // test cases


### PR DESCRIPTION
## What changed

- Allow `Picture` breakpoints to be complete media conditions such as `(orientation: landscape)`.
- Preserve existing numeric breakpoint behavior by continuing to translate numbers into `max-width` conditions.
- Use the same media-condition formatting for art-directed `<source media>` attributes and generated single-image `sizes` attributes.
- Preserve the existing exported `flattenSrc()` result shape.
- Document the expanded API and add regression coverage for string and mixed numeric/string breakpoints.

## Why

Art-directed images sometimes need to switch on conditions other than viewport width. Passing complete media conditions makes those cases possible without breaking existing pixel-width configurations.

## Validation

- `npm test` — 6 tests passed
- `npm run format:check`
