### PR TITLE
Fix CLI build with Next.js 16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.6.0
 
 - Add support for React 19 and Next.js 16 (React 18 still supported)
+- Fix `next-img` CLI hanging with Next.js 16.2 by explicitly using webpack
 - Replace ESLint/Healthier with OxLint
 - Replace react-test-renderer with react-dom/server in tests
 - Upgrade dependencies (sharp, qs, rimraf, prettier, ava)

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,9 +1,10 @@
 const path = require('path')
 const { existsSync } = require('fs')
 const loader = require('./loader')
+const createNextBuild = require('./next-build')
 
 const base = require.resolve('next', { paths: ['.'] }).replace('/dist/server/next.js', '')
-const { default: nextBuild } = require(`${base}/dist/build`)
+const nextBuild = createNextBuild(base)
 const { Command } = require(`${base}/dist/compiled/commander`)
 
 const program = new Command()

--- a/lib/next-build.js
+++ b/lib/next-build.js
@@ -1,0 +1,18 @@
+const path = require('path')
+const { existsSync } = require('fs')
+
+module.exports = function createNextBuild(base) {
+  const { default: nextBuild } = require(path.join(base, 'dist/build'))
+  const bundlerPath = path.join(base, 'dist/lib/bundler')
+
+  // Next.js 16 changed the default bundler of its internal build function to
+  // Turbopack. next-img relies on webpack's loader API, so select webpack
+  // explicitly when the Next.js bundler API is available.
+  if (existsSync(`${bundlerPath}.js`)) {
+    const { Bundler } = require(bundlerPath)
+
+    return dir => nextBuild(dir, undefined, undefined, undefined, undefined, undefined, undefined, Bundler.Webpack)
+  }
+
+  return nextBuild
+}

--- a/test/next-build.test.js
+++ b/test/next-build.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const test = require('ava')
+const createNextBuild = require('../lib/next-build')
+
+function createNextFixture(t, { bundler } = {}) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'next-img-'))
+  const dist = path.join(base, 'dist')
+
+  fs.mkdirSync(path.join(dist, 'lib'), { recursive: true })
+  fs.writeFileSync(path.join(dist, 'build.js'), 'module.exports.default = (...args) => args')
+
+  if (bundler) {
+    fs.writeFileSync(path.join(dist, 'lib/bundler.js'), `exports.Bundler = ${JSON.stringify(bundler)}`)
+  }
+
+  t.teardown(() => fs.rmSync(base, { recursive: true, force: true }))
+  return base
+}
+
+test('selects webpack when Next.js exposes its bundler API', t => {
+  const base = createNextFixture(t, { bundler: { Turbopack: 0, Webpack: 1 } })
+  const nextBuild = createNextBuild(base)
+
+  t.deepEqual(nextBuild('/app'), ['/app', undefined, undefined, undefined, undefined, undefined, undefined, 1])
+})
+
+test('supports Next.js versions without the bundler API', t => {
+  const base = createNextFixture(t)
+  const nextBuild = createNextBuild(base)
+
+  t.deepEqual(nextBuild('/app'), ['/app'])
+})


### PR DESCRIPTION
## What changed

- explicitly select webpack when calling Next.js’s internal build function
- preserve compatibility with older Next.js versions that do not expose the bundler API
- add regression coverage for both paths
- document the fix in the 0.6.0 changelog

## Why

Next.js 16.2 changed the default bundler of its internal build function to Turbopack. The `next-img` CLI called that function without selecting a bundler, so it entered Turbopack even though `next-img` depends on webpack’s loader API. The build then stalled before processing any images.

## Impact

Running `next-img` with Next.js 16.2 now uses webpack explicitly and rebuilds the persistent image cache as expected. Older supported Next.js versions retain their previous behavior.

## Validation

- `npm test` — 5 tests passed
- end-to-end run against Humaans on Next.js 16.2.12 reached image cache processing immediately; the later build failure was limited to unavailable Google Fonts in the sandbox
