### PR TITLE
Preserve Next image loader constraints

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -67,6 +67,7 @@ module.exports = function withImg(extraNextConfig = {}) {
       webpackConfig.module.rules = webpackConfig.module.rules.map(r =>
         r.loader === 'next-image-loader'
           ? {
+              ...r,
               test: /\.(jpe?g|png|webp)$/i,
               loader: path.join(__dirname, 'loader'),
               options: loaderOptions,

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,0 +1,38 @@
+const path = require('path')
+const { default: test } = require('ava')
+const withImg = require('../lib/plugin')
+
+test('preserves constraints from the Next.js image loader rule', t => {
+  const issuer = { not: [/\.css$/] }
+  const dependency = { not: ['url'] }
+  const resourceQuery = { not: [/__next_metadata__/, /__next_metadata_route__/] }
+  const webpackConfig = {
+    cache: true,
+    module: {
+      rules: [
+        {
+          test: /\.(png|jpg)$/i,
+          loader: 'next-image-loader',
+          issuer,
+          dependency,
+          resourceQuery,
+          options: { isDev: true },
+        },
+      ],
+    },
+  }
+
+  const config = withImg({ nextImg: { persistentCache: false } })
+  const result = config.webpack(webpackConfig, {
+    isServer: false,
+    dir: '/app',
+    dev: true,
+    config: { distDir: '.next', assetPrefix: '' },
+  })
+  const rule = result.module.rules[0]
+
+  t.is(rule.loader, path.join(__dirname, '../lib/loader'))
+  t.is(rule.issuer, issuer)
+  t.is(rule.dependency, dependency)
+  t.is(rule.resourceQuery, resourceQuery)
+})


### PR DESCRIPTION
## What changed

- preserve the original Next.js image loader rule constraints when substituting the `next-img` loader
- add regression coverage for `issuer`, `dependency`, and metadata `resourceQuery` exclusions

## Why

Reconstructing the rule from scratch discarded Next.js exclusions for App Router metadata images. As a result, files such as `app/apple-icon.png` could enter the `next-img` loader chain and fail to build.

## Impact

App Router metadata images continue through Next.js's dedicated metadata loader while ordinary supported image imports continue through `next-img`.

## Validation

- `npm test` — 7 tests passed
- `npm run format:check`

Closes #29
