### PR TITLE
Deduplicate clamped image widths

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -86,13 +86,17 @@ async function load(filePath, buffer) {
   const img = sharp(buffer)
   const metadata = await img.metadata()
   const images = []
+  const sizes = [...new Set(config.sizes.map(size => Math.min(metadata.width, size)))]
+  const processedWidths = new Set()
   const originalFileName = createFileName({ template: '[name].[ext]' })
 
-  for (let size of config.sizes) {
-    size = Math.min(metadata.width, size)
+  for (const size of sizes) {
     for (let density of config.densities) {
       density = parseInt(density, 10)
       const width = Math.min(metadata.width, size * density)
+
+      if (processedWidths.has(width)) continue
+      processedWidths.add(width)
 
       const resize = async (outputFormat, outputOptions) => {
         const progress = `${green('wait')}  - processing image ${originalFileName} → ${size}@${density}x`
@@ -132,7 +136,7 @@ async function load(filePath, buffer) {
     webpSrcSet: toSrcSet(images.filter(i => i.format === 'webp')),
     images,
     name: originalFileName,
-    sizes: [...new Set(images.map(i => i.size))],
+    sizes,
     breakpoints: config.breakpoints,
   })}`
 }

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,0 +1,97 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { default: test } = require('ava')
+const sharp = require('sharp')
+const loader = require('../lib/loader')
+
+async function runLoader(t, resourceQuery = '') {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'next-img-loader-'))
+  const emitted = []
+  const buffer = await sharp({
+    create: {
+      width: 800,
+      height: 500,
+      channels: 3,
+      background: { r: 20, g: 40, b: 60 },
+    },
+  })
+    .jpeg()
+    .toBuffer()
+
+  t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  const source = await new Promise((resolve, reject) => {
+    loader.call(
+      {
+        resourcePath: path.join(dir, 'image.jpg'),
+        resourceQuery,
+        rootContext: dir,
+        async: () => (error, result) => (error ? reject(error) : resolve(result)),
+        emitFile: (fileName, data) => emitted.push({ fileName, data }),
+        getOptions: () => ({
+          breakpoints: [768],
+          densities: ['1x', '2x'],
+          jpeg: {
+            quality: 80,
+            webp: { quality: 90 },
+          },
+          png: {
+            quality: 100,
+            webp: { lossless: true },
+          },
+          imagesName: '[name]-[size]@[density]-[hash].[ext]',
+          dir,
+          distDir: '.next',
+          publicPath: '/images/',
+          outputPath: 'images',
+          cacheDir: path.join('cache', 'next-img'),
+          persistentCache: false,
+          persistentCacheDir: 'resources',
+          failOnCacheMiss: false,
+          rebuildPersistentCache: false,
+        }),
+      },
+      buffer,
+    )
+  })
+
+  return {
+    data: JSON.parse(source.replace(/^module\.exports = /, '')),
+    emitted,
+  }
+}
+
+test('emits one candidate per format when sizes are omitted', async t => {
+  const { data, emitted } = await runLoader(t)
+
+  t.deepEqual(
+    data.images.map(({ width, format }) => ({ width, format })),
+    [
+      { width: 800, format: 'jpeg' },
+      { width: 800, format: 'webp' },
+    ],
+  )
+  t.deepEqual(data.sizes, [800])
+  t.is(data.srcSet.split(',').length, 1)
+  t.is(data.webpSrcSet.split(',').length, 1)
+  t.is(emitted.length, 2)
+})
+
+test('deduplicates widths produced by different size and density combinations', async t => {
+  const { data, emitted } = await runLoader(t, '?sizes=400,800')
+
+  t.deepEqual(
+    data.images.map(({ width, format }) => ({ width, format })),
+    [
+      { width: 400, format: 'jpeg' },
+      { width: 400, format: 'webp' },
+      { width: 800, format: 'jpeg' },
+      { width: 800, format: 'webp' },
+    ],
+  )
+  t.deepEqual(data.sizes, [400, 800])
+  t.is(data.srcSet.split(',').length, 2)
+  t.is(data.webpSrcSet.split(',').length, 2)
+  t.is(emitted.length, 4)
+})


### PR DESCRIPTION
## What changed

- normalize requested sizes against the source image width
- process each effective width only once across overlapping size and density combinations
- preserve logical `sizes` metadata independently from emitted image variants
- add loader-level regression tests using real Sharp output

## Why

When a requested size or density exceeded the source image width, multiple combinations could clamp to the same width. The loader still emitted each combination, producing duplicate files and duplicate width descriptors in `srcset`.

## Impact

Imports without `sizes` now emit one candidate per output format at the original width. Explicit size and density combinations also reuse candidates whenever they resolve to the same effective width.

## Validation

- `npm test` — 8 tests passed
- `npm run format:check`

Closes #1
