### PR TITLE
Make image cache maintenance incremental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.1
+
+- `npx next-img` now reuses healthy cached derivatives, repairs missing or invalid files, and removes unused files without re-encoding cache hits.
+- Add `npx next-img --force` to rebuild every active derivative before removing unused files.
+
 ## 0.6.0
 
 Existing `?sizes` imports, `src={[...]}` art direction, `persistentCache`, and `persistentCacheDir` remain supported.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Legacy image arrays remain supported through `src={[mobile, desktop]}` with `bre
 
 Optimized files are stored in `resources` by default. Commit this directory or preserve it in CI. Ordinary development and production builds process missing images.
 
-Run the CLI after changing imports, image settings, or Sharp versions. It rebuilds active images and removes unused files:
+Run the CLI after changing imports or image settings. It generates missing images, repairs invalid files, and removes unused files without re-encoding healthy cache hits:
 
 ```sh
 npx next-img
@@ -130,7 +130,7 @@ module.exports = withImg({
 })
 ```
 
-Cache filenames remain stable across next-img and Sharp upgrades. `npx next-img` always regenerates every referenced derivative in place, then removes unused files. Run it after upgrading next-img or Sharp.
+Cache filenames remain stable across next-img and Sharp upgrades. Run `npx next-img --force` when you want to rebuild every active derivative in place. Both commands remove unused files.
 
 The maintenance command requires a persistent cache. With `cache.mode: 'off'`, clear `.next` after upgrading next-img or Sharp instead.
 

--- a/lib/asset-store.js
+++ b/lib/asset-store.js
@@ -8,27 +8,30 @@ const { resolveCacheConfig } = require('./cache-config')
 const { normalizeSharpFormat } = require('./formats')
 const pending = new Map()
 
-async function cached(create, cacheKey, config, progressMessage) {
+async function cached(create, cacheKey, config, progressMessage, expected = {}) {
   const store = resolveStore(config)
   const cacheDir = store.dir
   const target = path.join(cacheDir, cacheKey)
 
   let cachedImage
-  if (!store.rebuilding) {
+  if (!store.force) {
     try {
       const data = await fs.readFile(target)
       const info = await sharp(data).metadata()
       const format = normalizeSharpFormat(info)
-      cachedImage = { data, width: info.width, height: info.height, format }
+      if (isHealthy(info, format, expected)) {
+        cachedImage = { data, width: info.width, height: info.height, format }
+      }
     } catch {}
   }
 
   if (cachedImage) {
     debug(`Cache hit ${cacheKey}`)
+    await recordUsed(cacheDir, cacheKey, store.maintenanceSession)
     return cachedImage
   }
 
-  if (store.readOnly && !store.rebuilding) {
+  if (store.readOnly && !store.maintaining) {
     throw new Error(`Missing an optimised image ${cacheKey}. Make sure to rerun next-img.`)
   }
 
@@ -51,7 +54,7 @@ async function cached(create, cacheKey, config, progressMessage) {
     )
   }
   const processed = await operation
-  await recordUsed(cacheDir, cacheKey, store.rebuildSession)
+  await recordUsed(cacheDir, cacheKey, store.maintenanceSession)
   return processed
 }
 
@@ -113,6 +116,12 @@ async function recordUsed(storeDir, fileName, session) {
   await writeFileAtomic(path.join(filesRoot, hash(fileName)), fileName)
 }
 
+function isHealthy(info, format, expected) {
+  if (!info.width || !info.height || !format) return false
+  if (expected.width && info.width !== expected.width) return false
+  return !expected.format || format === expected.format
+}
+
 async function pruneStore(storeDir, used) {
   const files = await listFiles(storeDir)
   for (const fileName of files) {
@@ -168,8 +177,9 @@ function resolveStore(config) {
     dir:
       cache.mode !== 'off' ? path.join(config.dir, cache.dir) : path.join(config.dir, config.distDir, config.cacheDir),
     readOnly: cache.mode === 'read-only',
-    rebuilding: Boolean(cache.rebuildSession),
-    rebuildSession: cache.rebuildSession,
+    maintaining: Boolean(cache.rebuildSession),
+    maintenanceSession: cache.rebuildSession,
+    force: Boolean(cache.force),
   }
 }
 

--- a/lib/asset-store.js
+++ b/lib/asset-store.js
@@ -8,7 +8,7 @@ const { resolveCacheConfig } = require('./cache-config')
 const { normalizeSharpFormat } = require('./formats')
 const pending = new Map()
 
-async function cached(create, cacheKey, config, progressMessage, expected = {}) {
+async function cached(create, cacheKey, config, progressMessage, { width: expectedWidth, format: expectedFormat }) {
   const store = resolveStore(config)
   const cacheDir = store.dir
   const target = path.join(cacheDir, cacheKey)
@@ -19,7 +19,7 @@ async function cached(create, cacheKey, config, progressMessage, expected = {}) 
       const data = await fs.readFile(target)
       const info = await sharp(data).metadata()
       const format = normalizeSharpFormat(info)
-      if (isHealthy(info, format, expected)) {
+      if (isHealthy(info, format, expectedWidth, expectedFormat)) {
         cachedImage = { data, width: info.width, height: info.height, format }
       }
     } catch {}
@@ -27,11 +27,11 @@ async function cached(create, cacheKey, config, progressMessage, expected = {}) 
 
   if (cachedImage) {
     debug(`Cache hit ${cacheKey}`)
-    await recordUsed(cacheDir, cacheKey, store.maintenanceSession)
+    await recordUsed(cacheDir, cacheKey, store.session)
     return cachedImage
   }
 
-  if (store.readOnly && !store.maintaining) {
+  if (store.readOnly && !store.session) {
     throw new Error(`Missing an optimised image ${cacheKey}. Make sure to rerun next-img.`)
   }
 
@@ -54,7 +54,7 @@ async function cached(create, cacheKey, config, progressMessage, expected = {}) 
     )
   }
   const processed = await operation
-  await recordUsed(cacheDir, cacheKey, store.maintenanceSession)
+  await recordUsed(cacheDir, cacheKey, store.session)
   return processed
 }
 
@@ -68,7 +68,7 @@ async function stage(fileName, data, config) {
   const target = resolveWithin(stageDir, fileName)
   await fs.mkdir(path.dirname(target), { recursive: true })
   await writeFileAtomic(target, data)
-  await recordUsed(stageDir, fileName, resolveCacheConfig(config).rebuildSession)
+  await recordUsed(stageDir, fileName, config.maintenance?.session)
   return target
 }
 
@@ -116,10 +116,9 @@ async function recordUsed(storeDir, fileName, session) {
   await writeFileAtomic(path.join(filesRoot, hash(fileName)), fileName)
 }
 
-function isHealthy(info, format, expected) {
+function isHealthy(info, format, expectedWidth, expectedFormat) {
   if (!info.width || !info.height || !format) return false
-  if (expected.width && info.width !== expected.width) return false
-  return !expected.format || format === expected.format
+  return info.width === expectedWidth && format === expectedFormat
 }
 
 async function pruneStore(storeDir, used) {
@@ -173,13 +172,13 @@ function getGcRoot(session) {
 
 function resolveStore(config) {
   const cache = resolveCacheConfig(config)
+  const session = config.maintenance?.session || null
   return {
     dir:
       cache.mode !== 'off' ? path.join(config.dir, cache.dir) : path.join(config.dir, config.distDir, config.cacheDir),
     readOnly: cache.mode === 'read-only',
-    maintaining: Boolean(cache.rebuildSession),
-    maintenanceSession: cache.rebuildSession,
-    force: Boolean(cache.force),
+    session,
+    force: Boolean(session && config.maintenance.force),
   }
 }
 

--- a/lib/cache-config.js
+++ b/lib/cache-config.js
@@ -12,13 +12,11 @@ function resolveCacheConfig(config) {
   } else if (
     hasOwn(config, 'persistentCache') ||
     hasOwn(config, 'persistentCacheDir') ||
-    hasOwn(config, 'failOnCacheMiss') ||
-    hasOwn(config, 'rebuildSession')
+    hasOwn(config, 'failOnCacheMiss')
   ) {
     cache = {
       mode: config.persistentCache === false ? 'off' : config.failOnCacheMiss ? 'read-only' : DEFAULT_CACHE.mode,
       dir: config.persistentCacheDir || DEFAULT_CACHE.dir,
-      rebuildSession: config.rebuildSession ?? null,
     }
   } else {
     cache = { ...DEFAULT_CACHE }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,12 +7,13 @@ const runNextBuild = require('./next-cli')
 
 const HELP = `Usage: next-img [options] [dir]
 
-Rebuilds all images in the configured cache and removes unused entries.
+Generates missing images and removes unused entries from the configured cache.
 
 Arguments:
   dir         directory of the Next.js application (defaults to current directory)
 
 Options:
+  --force     rebuild every active image before removing unused entries
   --webpack   rebuild using webpack instead of Turbopack
   -h, --help  display help for command`
 
@@ -22,12 +23,18 @@ function parseCommandLine(args) {
     allowPositionals: true,
     strict: true,
     options: {
+      force: { type: 'boolean' },
       webpack: { type: 'boolean' },
       help: { type: 'boolean', short: 'h' },
     },
   })
   if (positionals.length > 1) throw new Error('next-img accepts at most one application directory')
-  return { dir: positionals[0], webpack: values.webpack || false, help: values.help || false }
+  return {
+    dir: positionals[0],
+    force: values.force || false,
+    webpack: values.webpack || false,
+    help: values.help || false,
+  }
 }
 
 async function main(args = process.argv.slice(2), dependencies = {}) {
@@ -70,10 +77,12 @@ async function main(args = process.argv.slice(2), dependencies = {}) {
     NEXT_IMG_REBUILD: session,
     NEXT_IMG_PROJECT_DIR: resolvedDir,
   }
+  if (options.force) buildEnv.NEXT_IMG_FORCE = '1'
+  else delete buildEnv.NEXT_IMG_FORCE
   delete buildEnv.TURBOPACK
 
   try {
-    log(`> Rebuilding next-img cache with ${bundler}`)
+    log(`> ${options.force ? 'Rebuilding' : 'Updating'} next-img cache with ${bundler}`)
     await build({ dir: resolvedDir, bundler, env: buildEnv })
     await gc(session)
     return 0

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -74,7 +74,7 @@ async function main(args = process.argv.slice(2), dependencies = {}) {
   const bundler = options.webpack ? 'webpack' : 'turbopack'
   const buildEnv = {
     ...env,
-    NEXT_IMG_REBUILD: session,
+    NEXT_IMG_MAINTENANCE: session,
     NEXT_IMG_PROJECT_DIR: resolvedDir,
   }
   if (options.force) buildEnv.NEXT_IMG_FORCE = '1'

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -86,6 +86,7 @@ async function load(filePath, buffer) {
         cacheKey,
         config,
         progress,
+        { width, format: outputFormat },
       )
 
       const attr = { size, density, width: dimensions.width, height: dimensions.height, format }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -113,7 +113,7 @@ module.exports = function withImg(extraNextConfig = {}) {
         )
       }
 
-      webpackConfig.cache = !shouldMaintainPersistentCache() ? webpackConfig.cache : false
+      if (loaderOptions.maintenance) webpackConfig.cache = false
 
       // oxlint-disable-next-line anti-slop/no-runtime-typeof -- The Next.js webpack hook is optional external configuration.
       if (typeof extraWebpack === 'function') {
@@ -198,8 +198,10 @@ function getLoaderOptions(pluginConfig, { bundler, dir, distDir, assetProxyDir }
     cacheDir,
     cache,
   } = pluginConfig
-  const rebuildSession = process.env.NEXT_IMG_REBUILD || null
-  const force = process.env.NEXT_IMG_FORCE === '1'
+  const maintenanceSession = process.env.NEXT_IMG_MAINTENANCE || null
+  const maintenance = maintenanceSession
+    ? { session: maintenanceSession, force: process.env.NEXT_IMG_FORCE === '1' }
+    : null
 
   return {
     breakpoints,
@@ -219,7 +221,8 @@ function getLoaderOptions(pluginConfig, { bundler, dir, distDir, assetProxyDir }
     ...(assetProxyDir && { assetProxyDir }),
     imagesName,
     cacheDir,
-    cache: { ...cache, rebuildSession, force },
+    cache,
+    maintenance,
     assetStageDir: path.join(dir, '.next-img', 'assets'),
   }
 }
@@ -290,11 +293,7 @@ function withExcludedQuery(resourceQuery, query) {
 }
 
 function assertPersistentCache(loaderOptions) {
-  if (loaderOptions.cache.rebuildSession && loaderOptions.cache.mode === 'off') {
+  if (loaderOptions.maintenance && loaderOptions.cache.mode === 'off') {
     throw new Error('The next-img cache maintenance command cannot be used when cache.mode is "off"')
   }
-}
-
-function shouldMaintainPersistentCache() {
-  return !!process.env.NEXT_IMG_REBUILD
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -113,7 +113,7 @@ module.exports = function withImg(extraNextConfig = {}) {
         )
       }
 
-      webpackConfig.cache = !shouldRebuildPersistentCache() ? webpackConfig.cache : false
+      webpackConfig.cache = !shouldMaintainPersistentCache() ? webpackConfig.cache : false
 
       // oxlint-disable-next-line anti-slop/no-runtime-typeof -- The Next.js webpack hook is optional external configuration.
       if (typeof extraWebpack === 'function') {
@@ -199,6 +199,7 @@ function getLoaderOptions(pluginConfig, { bundler, dir, distDir, assetProxyDir }
     cache,
   } = pluginConfig
   const rebuildSession = process.env.NEXT_IMG_REBUILD || null
+  const force = process.env.NEXT_IMG_FORCE === '1'
 
   return {
     breakpoints,
@@ -218,7 +219,7 @@ function getLoaderOptions(pluginConfig, { bundler, dir, distDir, assetProxyDir }
     ...(assetProxyDir && { assetProxyDir }),
     imagesName,
     cacheDir,
-    cache: { ...cache, rebuildSession },
+    cache: { ...cache, rebuildSession, force },
     assetStageDir: path.join(dir, '.next-img', 'assets'),
   }
 }
@@ -290,10 +291,10 @@ function withExcludedQuery(resourceQuery, query) {
 
 function assertPersistentCache(loaderOptions) {
   if (loaderOptions.cache.rebuildSession && loaderOptions.cache.mode === 'off') {
-    throw new Error('The next-img cache rebuild command cannot be used when cache.mode is "off"')
+    throw new Error('The next-img cache maintenance command cannot be used when cache.mode is "off"')
   }
 }
 
-function shouldRebuildPersistentCache() {
+function shouldMaintainPersistentCache() {
   return !!process.env.NEXT_IMG_REBUILD
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-img",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next-img",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-img",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "",
   "license": "ISC",
   "author": "",

--- a/test/asset-store.test.js
+++ b/test/asset-store.test.js
@@ -75,7 +75,7 @@ test('coalesces concurrent transformations for the same cache entry', async t =>
   t.is(transformations, 1)
 })
 
-test('read-only cache mode rejects misses except during rebuilds', async t => {
+test('read-only cache mode rejects misses except during maintenance', async t => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'next-img-store-'))
   const session = `read-only-${process.pid}-${Date.now()}`
   const data = await createImage('red')
@@ -100,11 +100,12 @@ test('read-only cache mode rejects misses except during rebuilds', async t => {
   t.true(fs.existsSync(path.join(dir, 'resources', 'missing.jpg')))
 })
 
-test('rebuild sessions regenerate existing files and remove legacy manifests', async t => {
+test('maintenance reuses healthy files and force refreshes them', async t => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'next-img-store-'))
   const cacheDir = path.join(dir, 'resources')
   const first = await createImage('red')
   const second = await createImage('blue')
+  const third = await createImage('green')
   let transformations = 0
   const config = {
     dir,
@@ -118,24 +119,77 @@ test('rebuild sessions regenerate existing files and remove legacy manifests', a
   }
 
   await assetStore.cached(create(first), 'stable.jpg', config, 'processing')
-  fs.writeFileSync(path.join(cacheDir, '.next-img-cache.json'), '{}')
+  fs.writeFileSync(path.join(cacheDir, 'unused.jpg'), first)
 
-  const cached = await assetStore.cached(create(second), 'stable.jpg', config, 'processing')
+  const maintenanceSession = `maintenance-${process.pid}-${Date.now()}`
+  const cached = await assetStore.cached(
+    create(second),
+    'stable.jpg',
+    { ...config, cache: { ...config.cache, rebuildSession: maintenanceSession } },
+    'processing',
+    { width: 8, format: 'jpeg' },
+  )
+  await assetStore.gc(maintenanceSession)
+
   t.deepEqual(cached.data, first)
   t.is(transformations, 1)
+  t.deepEqual(fs.readdirSync(cacheDir), ['stable.jpg'])
 
-  const rebuildSession = `rebuild-${process.pid}-${Date.now()}`
+  const forceSession = `force-${process.pid}-${Date.now()}`
   await assetStore.cached(
     create(second),
     'stable.jpg',
-    { ...config, cache: { ...config.cache, rebuildSession } },
+    { ...config, cache: { ...config.cache, rebuildSession: forceSession, force: true } },
     'processing',
+    { width: 8, format: 'jpeg' },
   )
-  await assetStore.gc(rebuildSession)
+  await assetStore.gc(forceSession)
 
   t.is(transformations, 2)
   t.deepEqual(fs.readFileSync(path.join(cacheDir, 'stable.jpg')), second)
-  t.deepEqual(fs.readdirSync(cacheDir), ['stable.jpg'])
+
+  const currentSession = `current-${process.pid}-${Date.now()}`
+  const current = await assetStore.cached(
+    create(third),
+    'stable.jpg',
+    { ...config, cache: { ...config.cache, rebuildSession: currentSession } },
+    'processing',
+    { width: 8, format: 'jpeg' },
+  )
+  await assetStore.gc(currentSession)
+
+  t.deepEqual(current.data, second)
+  t.is(transformations, 2)
+})
+
+test('maintenance repairs invalid or unexpected derivatives', async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'next-img-store-'))
+  const cacheDir = path.join(dir, 'resources')
+  const data = await createImage('green')
+  let transformations = 0
+  const create = async () => {
+    transformations += 1
+    return { data, width: 8, height: 8, format: 'jpeg' }
+  }
+  t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  fs.mkdirSync(cacheDir, { recursive: true })
+  fs.writeFileSync(path.join(cacheDir, 'invalid.jpg'), 'not an image')
+  fs.writeFileSync(path.join(cacheDir, 'wrong-size.jpg'), await createImage('red'))
+
+  const session = `repair-${process.pid}-${Date.now()}`
+  const config = {
+    dir,
+    cache: { mode: 'read-write', dir: 'resources', rebuildSession: session },
+  }
+  await assetStore.cached(create, 'invalid.jpg', config, 'processing', { width: 8, format: 'jpeg' })
+  await assetStore.cached(create, 'wrong-size.jpg', config, 'processing', { width: 16, format: 'jpeg' })
+  await assetStore.cached(create, 'invalid.jpg', config, 'processing', { width: 8, format: 'jpeg' })
+  await assetStore.gc(session)
+
+  t.is(transformations, 2)
+  t.deepEqual(fs.readFileSync(path.join(cacheDir, 'invalid.jpg')), data)
+  t.deepEqual(fs.readFileSync(path.join(cacheDir, 'wrong-size.jpg')), data)
 })
 
 async function createImage(background) {

--- a/test/asset-store.test.js
+++ b/test/asset-store.test.js
@@ -28,15 +28,18 @@ test('garbage collection uses filesystem markers from build workers', async t =>
     'used.jpg',
     {
       dir,
-      cache: { mode: 'read-write', dir: 'resources', rebuildSession: session },
+      cache: { mode: 'read-write', dir: 'resources' },
+      maintenance: { session, force: false },
       assetStageDir: stageDir,
     },
     'processing test image',
+    { width: 8, format: 'jpeg' },
   )
   fs.writeFileSync(path.join(cacheDir, 'unused.jpg'), 'unused')
   await assetStore.stage('used.jpg', data, {
     assetStageDir: stageDir,
-    cache: { mode: 'read-write', dir: 'resources', rebuildSession: session },
+    cache: { mode: 'read-write', dir: 'resources' },
+    maintenance: { session, force: false },
   })
   fs.writeFileSync(path.join(stageDir, 'unused.jpg'), 'unused')
 
@@ -58,7 +61,7 @@ test('coalesces concurrent transformations for the same cache entry', async t =>
     dir,
     distDir: '.next',
     cacheDir: path.join('cache', 'next-img'),
-    cache: { mode: 'off', dir: 'resources', rebuildSession: null },
+    cache: { mode: 'off', dir: 'resources' },
   }
   const create = async () => {
     transformations += 1
@@ -68,8 +71,8 @@ test('coalesces concurrent transformations for the same cache entry', async t =>
   t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }))
 
   await Promise.all([
-    assetStore.cached(create, 'same.jpg', config, 'processing'),
-    assetStore.cached(create, 'same.jpg', config, 'processing'),
+    assetStore.cached(create, 'same.jpg', config, 'processing', { width: 8, format: 'jpeg' }),
+    assetStore.cached(create, 'same.jpg', config, 'processing', { width: 8, format: 'jpeg' }),
   ])
 
   t.is(transformations, 1)
@@ -81,21 +84,19 @@ test('read-only cache mode rejects misses except during maintenance', async t =>
   const data = await createImage('red')
   const config = {
     dir,
-    cache: { mode: 'read-only', dir: 'resources', rebuildSession: null },
+    cache: { mode: 'read-only', dir: 'resources' },
   }
   const create = async () => ({ data, width: 8, height: 8, format: 'jpeg' })
   t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }))
 
-  await t.throwsAsync(assetStore.cached(create, 'missing.jpg', config, 'processing'), {
+  await t.throwsAsync(assetStore.cached(create, 'missing.jpg', config, 'processing', { width: 8, format: 'jpeg' }), {
     message: /Missing an optimised image/,
   })
 
-  await assetStore.cached(
-    create,
-    'missing.jpg',
-    { ...config, cache: { ...config.cache, rebuildSession: session } },
-    'processing',
-  )
+  await assetStore.cached(create, 'missing.jpg', { ...config, maintenance: { session, force: false } }, 'processing', {
+    width: 8,
+    format: 'jpeg',
+  })
   await assetStore.discardGcSession(session)
   t.true(fs.existsSync(path.join(dir, 'resources', 'missing.jpg')))
 })
@@ -109,7 +110,7 @@ test('maintenance reuses healthy files and force refreshes them', async t => {
   let transformations = 0
   const config = {
     dir,
-    cache: { mode: 'read-write', dir: 'resources', rebuildSession: null },
+    cache: { mode: 'read-write', dir: 'resources' },
   }
   t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }))
 
@@ -118,14 +119,14 @@ test('maintenance reuses healthy files and force refreshes them', async t => {
     return { data, width: 8, height: 8, format: 'jpeg' }
   }
 
-  await assetStore.cached(create(first), 'stable.jpg', config, 'processing')
+  await assetStore.cached(create(first), 'stable.jpg', config, 'processing', { width: 8, format: 'jpeg' })
   fs.writeFileSync(path.join(cacheDir, 'unused.jpg'), first)
 
   const maintenanceSession = `maintenance-${process.pid}-${Date.now()}`
   const cached = await assetStore.cached(
     create(second),
     'stable.jpg',
-    { ...config, cache: { ...config.cache, rebuildSession: maintenanceSession } },
+    { ...config, maintenance: { session: maintenanceSession, force: false } },
     'processing',
     { width: 8, format: 'jpeg' },
   )
@@ -139,7 +140,7 @@ test('maintenance reuses healthy files and force refreshes them', async t => {
   await assetStore.cached(
     create(second),
     'stable.jpg',
-    { ...config, cache: { ...config.cache, rebuildSession: forceSession, force: true } },
+    { ...config, maintenance: { session: forceSession, force: true } },
     'processing',
     { width: 8, format: 'jpeg' },
   )
@@ -152,7 +153,7 @@ test('maintenance reuses healthy files and force refreshes them', async t => {
   const current = await assetStore.cached(
     create(third),
     'stable.jpg',
-    { ...config, cache: { ...config.cache, rebuildSession: currentSession } },
+    { ...config, maintenance: { session: currentSession, force: false } },
     'processing',
     { width: 8, format: 'jpeg' },
   )
@@ -165,11 +166,12 @@ test('maintenance reuses healthy files and force refreshes them', async t => {
 test('maintenance repairs invalid or unexpected derivatives', async t => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'next-img-store-'))
   const cacheDir = path.join(dir, 'resources')
-  const data = await createImage('green')
+  const small = await createImage('green')
+  const large = await createImage('green', 16)
   let transformations = 0
-  const create = async () => {
+  const create = (data, size) => async () => {
     transformations += 1
-    return { data, width: 8, height: 8, format: 'jpeg' }
+    return { data, width: size, height: size, format: 'jpeg' }
   }
   t.teardown(() => fs.rmSync(dir, { recursive: true, force: true }))
 
@@ -180,21 +182,22 @@ test('maintenance repairs invalid or unexpected derivatives', async t => {
   const session = `repair-${process.pid}-${Date.now()}`
   const config = {
     dir,
-    cache: { mode: 'read-write', dir: 'resources', rebuildSession: session },
+    cache: { mode: 'read-write', dir: 'resources' },
+    maintenance: { session, force: false },
   }
-  await assetStore.cached(create, 'invalid.jpg', config, 'processing', { width: 8, format: 'jpeg' })
-  await assetStore.cached(create, 'wrong-size.jpg', config, 'processing', { width: 16, format: 'jpeg' })
-  await assetStore.cached(create, 'invalid.jpg', config, 'processing', { width: 8, format: 'jpeg' })
+  await assetStore.cached(create(small, 8), 'invalid.jpg', config, 'processing', { width: 8, format: 'jpeg' })
+  await assetStore.cached(create(large, 16), 'wrong-size.jpg', config, 'processing', { width: 16, format: 'jpeg' })
+  await assetStore.cached(create(small, 8), 'invalid.jpg', config, 'processing', { width: 8, format: 'jpeg' })
   await assetStore.gc(session)
 
   t.is(transformations, 2)
-  t.deepEqual(fs.readFileSync(path.join(cacheDir, 'invalid.jpg')), data)
-  t.deepEqual(fs.readFileSync(path.join(cacheDir, 'wrong-size.jpg')), data)
+  t.deepEqual(fs.readFileSync(path.join(cacheDir, 'invalid.jpg')), small)
+  t.deepEqual(fs.readFileSync(path.join(cacheDir, 'wrong-size.jpg')), large)
 })
 
-async function createImage(background) {
+async function createImage(background, size = 8) {
   return sharp({
-    create: { width: 8, height: 8, channels: 3, background },
+    create: { width: size, height: size, channels: 3, background },
   })
     .jpeg()
     .toBuffer()

--- a/test/cache-config.test.js
+++ b/test/cache-config.test.js
@@ -4,10 +4,9 @@ const { resolveCacheConfig } = require('../lib/cache-config')
 test('resolves canonical cache configuration and defaults', t => {
   t.deepEqual(resolveCacheConfig({}), { mode: 'read-write', dir: 'resources' })
   t.deepEqual(resolveCacheConfig({ cache: null }), { mode: 'read-write', dir: 'resources' })
-  t.deepEqual(resolveCacheConfig({ cache: { mode: 'read-only', rebuildSession: 'session' } }), {
+  t.deepEqual(resolveCacheConfig({ cache: { mode: 'read-only' } }), {
     mode: 'read-only',
     dir: 'resources',
-    rebuildSession: 'session',
   })
 })
 
@@ -17,18 +16,15 @@ test('normalizes legacy loader cache options at the compatibility boundary', t =
       persistentCache: true,
       persistentCacheDir: 'legacy-resources',
       failOnCacheMiss: true,
-      rebuildSession: null,
     }),
     {
       mode: 'read-only',
       dir: 'legacy-resources',
-      rebuildSession: null,
     },
   )
   t.deepEqual(resolveCacheConfig({ persistentCache: false }), {
     mode: 'off',
     dir: 'resources',
-    rebuildSession: null,
   })
 })
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -34,7 +34,7 @@ test('runs and garbage collects cache maintenance', async t => {
   t.is(builds[0].dir, '/project/app')
   t.is(builds[0].bundler, 'webpack')
   t.false('TURBOPACK' in builds[0].env)
-  t.is(builds[0].env.NEXT_IMG_REBUILD, sessions[0])
+  t.is(builds[0].env.NEXT_IMG_MAINTENANCE, sessions[0])
   t.false('NEXT_IMG_FORCE' in builds[0].env)
 })
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -4,13 +4,20 @@ const { main, parseCommandLine } = require('../lib/cli')
 test('parses the built-in CLI options', t => {
   t.deepEqual(parseCommandLine(['--webpack', './app']), {
     dir: './app',
+    force: false,
     webpack: true,
+    help: false,
+  })
+  t.deepEqual(parseCommandLine(['--force']), {
+    dir: undefined,
+    force: true,
+    webpack: false,
     help: false,
   })
   t.throws(() => parseCommandLine(['one', 'two']), { message: /at most one/ })
 })
 
-test('runs and garbage collects a cache rebuild', async t => {
+test('runs and garbage collects cache maintenance', async t => {
   const builds = []
   const sessions = []
   const code = await main(['--webpack', 'app'], {
@@ -28,6 +35,23 @@ test('runs and garbage collects a cache rebuild', async t => {
   t.is(builds[0].bundler, 'webpack')
   t.false('TURBOPACK' in builds[0].env)
   t.is(builds[0].env.NEXT_IMG_REBUILD, sessions[0])
+  t.false('NEXT_IMG_FORCE' in builds[0].env)
+})
+
+test('passes the force flag to the cleanup build', async t => {
+  const builds = []
+  const code = await main(['--force'], {
+    cwd: '/project',
+    env: {},
+    exists: () => true,
+    log: () => {},
+    error: t.fail,
+    build: async options => builds.push(options),
+    gc: async () => {},
+  })
+
+  t.is(code, 0)
+  t.is(builds[0].env.NEXT_IMG_FORCE, '1')
 })
 
 test('discards rebuild markers when the build fails', async t => {

--- a/test/generated-asset-loader.test.js
+++ b/test/generated-asset-loader.test.js
@@ -26,7 +26,7 @@ test('reads optimized bytes from the content-addressed cache', async t => {
     dir,
     distDir: '.next',
     cacheDir: path.join('cache', 'next-img'),
-    cache: { mode: 'off', dir: 'resources', rebuildSession: null },
+    cache: { mode: 'off', dir: 'resources' },
   })
 
   t.deepEqual(actual, expected)
@@ -37,7 +37,7 @@ test('rejects missing and unsafe cache keys', async t => {
     dir: os.tmpdir(),
     distDir: '.next',
     cacheDir: path.join('cache', 'next-img'),
-    cache: { mode: 'off', dir: 'resources', rebuildSession: null },
+    cache: { mode: 'off', dir: 'resources' },
   }
 
   await t.throwsAsync(runLoader('?__next_img_generated__', config), { message: /without a cache key/ })

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -49,7 +49,8 @@ async function runLoader(t, resourceQuery = '', optionOverrides = {}, inputBuffe
           dir,
           distDir: '.next',
           cacheDir: path.join('cache', 'next-img'),
-          cache: { mode: 'off', dir: 'resources', rebuildSession: null, force: false },
+          cache: { mode: 'off', dir: 'resources' },
+          maintenance: null,
           assetStageDir: path.join(dir, '.next-img', 'assets'),
           bundler: 'webpack',
           ...optionOverrides,
@@ -146,7 +147,7 @@ test.serial('preserves released persistent cache keys with pinned hashing across
   const originalSharpVersion = sharp.versions.sharp
 
   try {
-    const cache = { mode: 'read-write', dir: 'resources', rebuildSession: null }
+    const cache = { mode: 'read-write', dir: 'resources' }
     const first = await runLoader(t, '', { cache })
     sharp.versions.sharp = '99.0.0'
     const second = await runLoader(t, '', { cache })
@@ -165,12 +166,7 @@ test('uses one derivative key for persistent and temporary caches', async t => {
   })
     .jpeg()
     .toBuffer()
-  const persistent = await runLoader(
-    t,
-    '',
-    { cache: { mode: 'read-write', dir: 'resources', rebuildSession: null } },
-    input,
-  )
+  const persistent = await runLoader(t, '', { cache: { mode: 'read-write', dir: 'resources' } }, input)
   const temporary = await runLoader(t, '', {}, input)
 
   t.deepEqual(getCacheKeys(temporary), getCacheKeys(persistent))

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -49,7 +49,7 @@ async function runLoader(t, resourceQuery = '', optionOverrides = {}, inputBuffe
           dir,
           distDir: '.next',
           cacheDir: path.join('cache', 'next-img'),
-          cache: { mode: 'off', dir: 'resources', rebuildSession: null },
+          cache: { mode: 'off', dir: 'resources', rebuildSession: null, force: false },
           assetStageDir: path.join(dir, '.next-img', 'assets'),
           bundler: 'webpack',
           ...optionOverrides,

--- a/test/next-cli.test.js
+++ b/test/next-cli.test.js
@@ -24,7 +24,7 @@ test('runs the target project Next.js CLI with the selected bundler', async t =>
     `require('fs').writeFileSync(process.env.CAPTURE_PATH, JSON.stringify({
       args: process.argv.slice(2),
       projectDir: process.env.NEXT_IMG_PROJECT_DIR,
-      session: process.env.NEXT_IMG_REBUILD,
+      session: process.env.NEXT_IMG_MAINTENANCE,
     }))`,
   )
   t.teardown(() => fs.rmSync(capturePath, { force: true }))
@@ -36,7 +36,7 @@ test('runs the target project Next.js CLI with the selected bundler', async t =>
       ...process.env,
       CAPTURE_PATH: capturePath,
       NEXT_IMG_PROJECT_DIR: dir,
-      NEXT_IMG_REBUILD: 'test-session',
+      NEXT_IMG_MAINTENANCE: 'test-session',
     },
   })
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -93,7 +93,8 @@ test('configures the shared loader and generated assets for Turbopack', t => {
 
   const options = loaderRule.loaders[0].options
   t.notThrows(() => JSON.stringify(options))
-  t.deepEqual(options.cache, { mode: 'off', dir: 'resources', rebuildSession: null, force: false })
+  t.deepEqual(options.cache, { mode: 'off', dir: 'resources' })
+  t.is(options.maintenance, null)
   t.is(options.maxBareImportSize, 2048)
   t.is(options.bundler, 'turbopack')
   t.regex(options.assetProxyDir, /\.next-img\/proxies$/)
@@ -115,18 +116,16 @@ test('supports explicit cache modes and legacy cache configuration', t => {
   t.deepEqual(readOnlyOptions.cache, {
     mode: 'read-only',
     dir: 'image-cache',
-    rebuildSession: null,
-    force: false,
   })
+  t.is(readOnlyOptions.maintenance, null)
 
   const legacy = withImg({ nextImg: { persistentCacheDir: 'legacy-cache' } })
   const legacyOptions = legacy.turbopack.rules['*.jpg'][1].loaders[0].options
   t.deepEqual(legacyOptions.cache, {
     mode: 'read-write',
     dir: 'legacy-cache',
-    rebuildSession: null,
-    force: false,
   })
+  t.is(legacyOptions.maintenance, null)
 })
 
 test('validates the oversized bare-import limit', t => {
@@ -137,32 +136,44 @@ test('validates the oversized bare-import limit', t => {
 })
 
 test.serial('passes force through to maintenance loaders', t => {
-  const previousRebuild = process.env.NEXT_IMG_REBUILD
+  const previousMaintenance = process.env.NEXT_IMG_MAINTENANCE
   const previousForce = process.env.NEXT_IMG_FORCE
-  process.env.NEXT_IMG_REBUILD = 'test-session'
+  process.env.NEXT_IMG_MAINTENANCE = 'test-session'
   process.env.NEXT_IMG_FORCE = '1'
   try {
     const config = withImg({})
     const options = config.turbopack.rules['*.jpg'][1].loaders[0].options
-    t.is(options.cache.rebuildSession, 'test-session')
-    t.true(options.cache.force)
+    t.deepEqual(options.maintenance, { session: 'test-session', force: true })
   } finally {
-    if (previousRebuild === undefined) delete process.env.NEXT_IMG_REBUILD
-    else process.env.NEXT_IMG_REBUILD = previousRebuild
+    if (previousMaintenance === undefined) delete process.env.NEXT_IMG_MAINTENANCE
+    else process.env.NEXT_IMG_MAINTENANCE = previousMaintenance
+    if (previousForce === undefined) delete process.env.NEXT_IMG_FORCE
+    else process.env.NEXT_IMG_FORCE = previousForce
+  }
+})
+
+test.serial('ignores force outside cache maintenance', t => {
+  const previousForce = process.env.NEXT_IMG_FORCE
+  process.env.NEXT_IMG_FORCE = '1'
+  try {
+    const config = withImg({})
+    const options = config.turbopack.rules['*.jpg'][1].loaders[0].options
+    t.is(options.maintenance, null)
+  } finally {
     if (previousForce === undefined) delete process.env.NEXT_IMG_FORCE
     else process.env.NEXT_IMG_FORCE = previousForce
   }
 })
 
 test.serial('rejects cache maintenance when caching is disabled', t => {
-  const previous = process.env.NEXT_IMG_REBUILD
-  process.env.NEXT_IMG_REBUILD = 'test-session'
+  const previous = process.env.NEXT_IMG_MAINTENANCE
+  process.env.NEXT_IMG_MAINTENANCE = 'test-session'
   try {
     t.throws(() => withImg({ nextImg: { cache: { mode: 'off' } } }), {
       message: /cannot be used when cache.mode is "off"/,
     })
   } finally {
-    if (previous === undefined) delete process.env.NEXT_IMG_REBUILD
-    else process.env.NEXT_IMG_REBUILD = previous
+    if (previous === undefined) delete process.env.NEXT_IMG_MAINTENANCE
+    else process.env.NEXT_IMG_MAINTENANCE = previous
   }
 })

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -93,7 +93,7 @@ test('configures the shared loader and generated assets for Turbopack', t => {
 
   const options = loaderRule.loaders[0].options
   t.notThrows(() => JSON.stringify(options))
-  t.deepEqual(options.cache, { mode: 'off', dir: 'resources', rebuildSession: null })
+  t.deepEqual(options.cache, { mode: 'off', dir: 'resources', rebuildSession: null, force: false })
   t.is(options.maxBareImportSize, 2048)
   t.is(options.bundler, 'turbopack')
   t.regex(options.assetProxyDir, /\.next-img\/proxies$/)
@@ -116,6 +116,7 @@ test('supports explicit cache modes and legacy cache configuration', t => {
     mode: 'read-only',
     dir: 'image-cache',
     rebuildSession: null,
+    force: false,
   })
 
   const legacy = withImg({ nextImg: { persistentCacheDir: 'legacy-cache' } })
@@ -124,6 +125,7 @@ test('supports explicit cache modes and legacy cache configuration', t => {
     mode: 'read-write',
     dir: 'legacy-cache',
     rebuildSession: null,
+    force: false,
   })
 })
 
@@ -134,7 +136,25 @@ test('validates the oversized bare-import limit', t => {
   t.notThrows(() => withImg({ nextImg: { maxBareImportSize: false } }))
 })
 
-test.serial('rejects cache rebuilds when caching is disabled', t => {
+test.serial('passes force through to maintenance loaders', t => {
+  const previousRebuild = process.env.NEXT_IMG_REBUILD
+  const previousForce = process.env.NEXT_IMG_FORCE
+  process.env.NEXT_IMG_REBUILD = 'test-session'
+  process.env.NEXT_IMG_FORCE = '1'
+  try {
+    const config = withImg({})
+    const options = config.turbopack.rules['*.jpg'][1].loaders[0].options
+    t.is(options.cache.rebuildSession, 'test-session')
+    t.true(options.cache.force)
+  } finally {
+    if (previousRebuild === undefined) delete process.env.NEXT_IMG_REBUILD
+    else process.env.NEXT_IMG_REBUILD = previousRebuild
+    if (previousForce === undefined) delete process.env.NEXT_IMG_FORCE
+    else process.env.NEXT_IMG_FORCE = previousForce
+  }
+})
+
+test.serial('rejects cache maintenance when caching is disabled', t => {
   const previous = process.env.NEXT_IMG_REBUILD
   process.env.NEXT_IMG_REBUILD = 'test-session'
   try {


### PR DESCRIPTION
## Summary

- Reuse healthy cached derivatives during `npx next-img`.
- Generate missing or invalid derivatives and remove unused files without re-encoding cache hits.
- Add `npx next-img --force` for explicit full rebuilds.
- Bump the package to 0.6.1 and document the new behavior.

## Why

The maintenance command rebuilt every active derivative, creating slow runs and large image-only diffs. Cache keys already change with the source and output settings, so healthy matching images can be reused safely.

## Validation

- `npm test` — 48 tests passed
- `npm run test:integration:webpack`
- `npm run format:check`
