### PR TITLE
Support fetch priority across React versions

### DIFF
--- a/lib/Picture.js
+++ b/lib/Picture.js
@@ -50,7 +50,7 @@ const Picture = React.forwardRef(function Picture(
       ...getDimensions(fallbackImage),
       loading: resolvedLoading,
       decoding,
-      fetchPriority: resolvedFetchPriority,
+      ...getFetchPriorityProps(resolvedFetchPriority),
     }),
   )
 
@@ -90,7 +90,12 @@ function createPreloads(pictureSources, requestOptions) {
     }
 
     const Head = require('next/head').default
-    return h(Head, { key: preloadKey(options) }, h('link', { rel: 'preload', href: undefined, ...options }))
+    const { fetchPriority, ...linkOptions } = options
+    return h(
+      Head,
+      { key: preloadKey(options) },
+      h('link', { rel: 'preload', href: undefined, ...linkOptions, ...getFetchPriorityProps(fetchPriority) }),
+    )
   })
 
   return preloads.some(Boolean) ? preloads : null
@@ -112,6 +117,12 @@ function firstSrcSetUrl(srcSet) {
 
 function withoutUndefined(value) {
   return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined))
+}
+
+function getFetchPriorityProps(fetchPriority) {
+  if (fetchPriority === undefined) return {}
+  // oxlint-disable-next-line anti-slop/no-runtime-typeof -- React 18/19 DOM property support requires feature detection.
+  return typeof ReactDOM.preload === 'function' ? { fetchPriority } : { fetchpriority: fetchPriority }
 }
 
 function preloadKey(options) {

--- a/test/Picture.test.js
+++ b/test/Picture.test.js
@@ -258,10 +258,11 @@ test.serial('preload falls back to the Pages Router head manager on React 18', t
   }
   const originalPreload = ReactDOM.preload
   const head = []
+  let html
 
   try {
     ReactDOM.preload = undefined
-    renderToStaticMarkup(
+    html = renderToStaticMarkup(
       <HeadManagerContext.Provider
         value={{ mountedInstances: new Set(), updateHead: elements => head.push(...elements) }}
       >
@@ -273,9 +274,13 @@ test.serial('preload falls back to the Pages Router head manager on React 18', t
   }
 
   const link = head.find(element => element.type === 'link' && element.props.rel === 'preload')
+  t.true(html.includes('fetchpriority="high"'))
+  t.false(html.includes('fetchPriority='))
   t.is(link.props.type, 'image/webp')
   t.is(link.props.imageSrcSet, 'hero.webp 800w')
   t.is(link.props.imageSizes, '800px')
+  t.is(link.props.fetchpriority, 'high')
+  t.false('fetchPriority' in link.props)
 })
 
 test('explicit art direction has one canonical source contract', t => {


### PR DESCRIPTION
## What changed

- render `fetchPriority` with React 19's camel-case DOM property
- render `fetchpriority` for React 18, which otherwise warns about the unknown camel-case prop
- apply the same compatibility behavior to Pages Router preload links
- cover the React 18 image and preload-link properties in the Picture tests

## Why

`Picture` supports React 18 and React 19, but the two renderers expect different property casing. Applications on React 18 currently receive a development warning when `preload` or `fetchPriority` is used.

Feature-detecting `ReactDOM.preload` keeps the modern React 19 path intact while producing warning-free DOM attributes for React 18.

## Validation

- `npm test` — 49 tests pass
- `npm run format:check`
- `npm run test:integration:turbopack`
- `npm run test:integration:webpack`
